### PR TITLE
make it possible to use ArabicDictionary with multiple threads.

### DIFF
--- a/arramooz/arabicdictionary.py
+++ b/arramooz/arabicdictionary.py
@@ -83,7 +83,7 @@ class ArabicDictionary:
 
         if os.path.exists(file_path):
             try:
-                self.db_connect = sqlite.connect(file_path, check_same_thread=false)
+                self.db_connect = sqlite.connect(file_path, check_same_thread=False)
                 self.db_connect.row_factory = sqlite.Row 
                 self.cursor = self.db_connect.cursor()
             except  IOError:

--- a/arramooz/arabicdictionary.py
+++ b/arramooz/arabicdictionary.py
@@ -83,7 +83,7 @@ class ArabicDictionary:
 
         if os.path.exists(file_path):
             try:
-                self.db_connect = sqlite.connect(file_path)                
+                self.db_connect = sqlite.connect(file_path, check_same_thread=false)
                 self.db_connect.row_factory = sqlite.Row 
                 self.cursor = self.db_connect.cursor()
             except  IOError:


### PR DESCRIPTION
Currently, if ArabicDictionary is used with multiple threads, it might fail with the error:
```
File xxx, in __check_word_exists_in_dictionary
    if self.dictionary_verbs.lookup(word.text) is None:
  File "/usr/local/lib/python3.8/site-packages/arramooz/arabicdictionary.py", line 229, in lookup
    self.cursor.execute(sql)
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id xxx and this is thread id xxx.
```

As ArabicDictionary doesn't use write operations, setting the `check_same_thread` to `False` is ok.
However if any write operation is to be implemented, when using multiple threads with the same connection writing operations should be serialized by the user to avoid data corruption.